### PR TITLE
fix:変化割合の計算で割り算のバグの修正

### DIFF
--- a/Windows/Slidebukkonuki_wintest/main.cpp
+++ b/Windows/Slidebukkonuki_wintest/main.cpp
@@ -64,10 +64,10 @@ bool compare_frames(Mat frame)
 	// printf("RGB合計：%ld\n", countRGB);
 	// printf("精査回数：%ld\n", count);
 	// printf("平均：%ld \n", countRGB / count);
-	printf("変化割合：%f\n", ((float)(countRGB / count) / 256) * 100);
+	printf("変化割合：%f\n", countRGB / (float)count / 256.0 * 100);
 
 	// 指定した閾値よりも変化しているか
-	return ((((float)(countRGB / count) / 256) * 100) > g_threshold);
+	return (countRGB / (float)count / 256.0 * 100) > g_threshold;
 }
 
 // 参考:https://kisqragi.hatenablog.com/entry/2019/11/02/130921

--- a/main.cpp
+++ b/main.cpp
@@ -65,10 +65,10 @@ bool compare_frames(Mat frame)
     // printf("RGB合計：%ld\n", countRGB);
     // printf("精査回数：%ld\n", count);
     // printf("平均：%ld \n", countRGB / count);
-    printf("変化割合：%f\n", ((float)(countRGB / count) / 256) * 100);
+    printf("変化割合：%f\n", countRGB / (float)count / 256.0 * 100);
 
     // 指定した閾値よりも変化しているか
-    return ((((float)(countRGB / count) / 256) * 100) > g_threshold);
+    return (countRGB / (float)count / 256.0 * 100) > g_threshold;
 }
 
 // 参考:https://kisqragi.hatenablog.com/entry/2019/11/02/130921


### PR DESCRIPTION
変化割合の計算式 `((float)(countRGB / count) / 256) * 100` は int同士の割り算 `countRGB / count` が最初に計算されてfloatに変換されます。したがってcountRGBがcountで割り切れない場合は少数以下が反映されずに意図しない結果になります。
よって count を最初にfloatに変換することで暗黙の型変換によってfloat同士の割り算になって正しい結果になりますので修正しました。